### PR TITLE
fix: 하나의 좌표값이 먼저 도달하면 해당 키가 멈추지 않던 오류 해결

### DIFF
--- a/mjs_agent/mjs_agent/movement.cpp
+++ b/mjs_agent/mjs_agent/movement.cpp
@@ -20,18 +20,19 @@ void Movement::MoveToPosition(double targetX, double targetZ, NetworkManager* ne
         double distance = std::sqrt(moveX * moveX + moveZ * moveZ);
 
         if (distance < threshold) {
-            if (movingX) {
-                InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', false);
-                movingX = false;
-            }
-            if (movingZ) {
-                InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', false);
-                movingZ = false;
-            }
             std::cout << "Reached!" << std::endl;
             networkmanager->SendDone();
             break;
         }
+        if (movingX && abs(moveX) < threshold) {
+            InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', false);
+            movingX = false;
+        }
+        if (movingZ && abs(moveZ) < threshold) {
+            InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', false);
+            movingZ = false;
+        }
+
         if (!movingX)
         {
             if (std::abs(moveX) > threshold) {

--- a/mjs_agent/mjs_agent/networkmanager.cpp
+++ b/mjs_agent/mjs_agent/networkmanager.cpp
@@ -152,7 +152,7 @@ void NetworkManager::TcpReceiverThread()
         
         if (bytesReceived >= sizeof(double) * 3) {
             std::cout << "target received. \n X:" << buffer[0] << " Y: " << buffer[1] << " Z: " << buffer[2] << std::endl;
-            movement->MoveToPosition(buffer[0], buffer[2], this, 0.5);
+            movement->MoveToPosition(buffer[0], buffer[2], this, 0.3);
             
         }
         else if (bytesReceived == 0) {


### PR DESCRIPTION
distance( 목표지점과의 거리)로만 계산해 키를 멈춰 정상적으로 멈추지 않던 문제 해결