### PR TITLE
fix: 상대 좌표 이동 프로토콜 변경

### DIFF
--- a/mjs_agent/mjs_agent/movement.cpp
+++ b/mjs_agent/mjs_agent/movement.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 
+// 절대 좌표 이동
 void Movement::MoveToPosition(double targetX, double targetZ, NetworkManager* networkmanager, double threshold)
 {
     InputManager::SendKeyInput('W', false);
@@ -67,53 +68,31 @@ void Movement::MoveToPosition(double targetX, double targetZ, NetworkManager* ne
     InputManager::SendKeyInput('D', false);
 }
 
-void Movement::MoveRelation(char target, double relativeX, double relativeZ, NetworkManager* networkmanager, double threshold)
+//상대 좌표 이동
+void Movement::MoveRelation(double relativeX, double relativeY, double relativeZ, NetworkManager* networkmanager, double threshold)
 {
-    // 모든 키 초기화
     InputManager::SendKeyInput('W', false);
     InputManager::SendKeyInput('A', false);
     InputManager::SendKeyInput('S', false);
     InputManager::SendKeyInput('D', false);
 
-    // 현재 위치 가져오기
     Position currentPosition = networkmanager->GetPosition();
     
-    // 상대 좌표를 절대 좌표로 변환
     double targetX = currentPosition.x + relativeX;
     double targetZ = currentPosition.z + relativeZ;
     
-    std::cout << "Relative Move - Target: " << (int)target 
-              << " | Relative: X=" << relativeX << " Z=" << relativeZ 
+    std::cout << "Relative Move - Relative: X=" << relativeX << " Z=" << relativeZ 
               << " | Absolute: X=" << targetX << " Z=" << targetZ << std::endl;
 
     bool movingX = false;
     bool movingZ = false;
-
-    // target에 따라 이동할 축 결정
-    // 0: X만, 2: Z만, 3: 둘 다
-    bool moveXAxis = (target == 0 || target == 3);
-    bool moveZAxis = (target == 2 || target == 3);
-
-    // X만 이동하는 경우 목표 Z를 현재 위치로 설정
-    if (target == 0) {
-        targetZ = currentPosition.z;
-    }
-    // Z만 이동하는 경우 목표 X를 현재 위치로 설정
-    else if (target == 2) {
-        targetX = currentPosition.x;
-    }
 
     while (networkmanager->IsUdpRunning()) {
         currentPosition = networkmanager->GetPosition();
 
         double moveX = targetX - currentPosition.x;
         double moveZ = targetZ - currentPosition.z;
-        
-        // 이동해야 할 축만 계산
-        double distance = 0.0;
-        if (moveXAxis) distance += moveX * moveX;
-        if (moveZAxis) distance += moveZ * moveZ;
-        distance = std::sqrt(distance);
+        double distance = std::sqrt(moveX * moveX + moveZ * moveZ);
 
         if (distance < threshold) {
             std::cout << "Reached relative position!" << std::endl;
@@ -121,48 +100,41 @@ void Movement::MoveRelation(char target, double relativeX, double relativeZ, Net
             break;
         }
 
-        // X축 이동 처리
-        if (moveXAxis) {
-            if (movingX && std::abs(moveX) < threshold) {
+        if (movingX && std::abs(moveX) < threshold) {
+            InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', false);
+            movingX = false;
+        }
+
+        if (!movingX) {
+            if (std::abs(moveX) > threshold) {
+                InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', true);
+                movingX = true;
+            }
+            else {
                 InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', false);
                 movingX = false;
             }
-
-            if (!movingX) {
-                if (std::abs(moveX) > threshold) {
-                    InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', true);
-                    movingX = true;
-                }
-                else {
-                    InputManager::SendKeyInput(moveX < 0 ? 'A' : 'D', false);
-                    movingX = false;
-                }
-            }
         }
 
-        // Z축 이동 처리
-        if (moveZAxis) {
-            if (movingZ && std::abs(moveZ) < threshold) {
+        if (movingZ && std::abs(moveZ) < threshold) {
+            InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', false);
+            movingZ = false;
+        }
+
+        if (!movingZ) {
+            if (std::abs(moveZ) > threshold) {
+                InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', true);
+                movingZ = true;
+            }
+            else {
                 InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', false);
                 movingZ = false;
-            }
-
-            if (!movingZ) {
-                if (std::abs(moveZ) > threshold) {
-                    InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', true);
-                    movingZ = true;
-                }
-                else {
-                    InputManager::SendKeyInput(moveZ < 0 ? 'W' : 'S', false);
-                    movingZ = false;
-                }
             }
         }
 
         Sleep(50);
     }
 
-    // 모든 키 해제
     InputManager::SendKeyInput('W', false);
     InputManager::SendKeyInput('A', false);
     InputManager::SendKeyInput('S', false);

--- a/mjs_agent/mjs_agent/movement.h
+++ b/mjs_agent/mjs_agent/movement.h
@@ -6,7 +6,7 @@ class NetworkManager;
 class Movement {
 public:
 	void MoveToPosition(double targetX, double targetZ, NetworkManager* networkmanager, double threshold);
-	void MoveRelation(char position, double targetX, double targetZ, NetworkManager* networkmanager, double threshold);
+	void MoveRelation(double targetX, double y, double targetZ, NetworkManager* networkmanager, double threshold);
 
 	bool movingX = false;
 	bool movingZ = false;

--- a/mjs_agent/mjs_agent/networkmanager.cpp
+++ b/mjs_agent/mjs_agent/networkmanager.cpp
@@ -173,16 +173,14 @@ void NetworkManager::TcpReceiverThread()
             
 
             if (mode == 1) {
-                if (bytesReceived >= 26) {
-                    char target = buffer[1];
-                    double* coords = reinterpret_cast<double*>(&buffer[2]);
+                if (bytesReceived >= 25) {
+                    double* coords = reinterpret_cast<double*>(&buffer[1]);
                     double x = coords[0];
                     double y = coords[1];
                     double z = coords[2];
                     
-                    std::cout << "Relative target received - Target: " << (int)target 
-                              << " X:" << x << " Y:" << y << " Z:" << z << std::endl;
-                    movement->MoveRelation(target, x, z, this, 0.5);
+                    std::cout << "Relative target received - Target: " << " X:" << x << " Y:" << y << " Z:" << z << std::endl;
+                    movement->MoveRelation(x, y, z, this, 0.5);
                 }
                 else {
                     std::cout << "Invalid mode 1 packet size: " << bytesReceived << std::endl;


### PR DESCRIPTION
기존에 X, Y, Z값중 어떤걸 상대 좌표로 이동할지 정하던 부분을 아예 지우고 
절대 좌표 이동과 동일한 형태로 변경
